### PR TITLE
Monkey patch scipy empty

### DIFF
--- a/balance/weighting_methods/ipw.py
+++ b/balance/weighting_methods/ipw.py
@@ -87,11 +87,20 @@ def _patch_scipy_random(*args, **kwds) -> Generator:
         else None
     )
     scipy.random = np.random
+
+    tmp_scipy_empty_func = (
+        # pyre-ignore[16]
+        scipy.empty
+        if hasattr(scipy, "empty")
+        else None
+    )
+    scipy.empty = np.empty
     try:
         yield
     finally:
         # undo the function swap
         scipy.random = tmp_scipy_random_func
+        scipy.empty = tmp_scipy_empty_func
 
 
 def cv_glmnet_performance(

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ REQUIRES = [
     "numpy",
     "pandas",
     "ipython",
-    "scipy",
+    "scipy==1.11.4",
     "patsy",
     "seaborn",
     "plotly",


### PR DESCRIPTION
Trying to fix the scipy empty problem that @crispy-wonton  had by monkey-patching it in a similar way to the scipy.random issue
```
"...asf_heat_pump_suitability/lib/python3.10/site-packages/glmnet_python/glmnetPredict.py", line 110, in <module>
    newx = scipy.empty([0]), \
  File ".../miniconda3/envs/asf_heat_pump_suitability/lib/python3.10/site-packages/scipy/__init__.py", line 139, in __getattr__
    raise AttributeError(
AttributeError: Module 'scipy' has no attribute 'empty'
```